### PR TITLE
Improve module filtering.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var detective = require('detective');
 var _ = require('lodash');
 var recursive = require('recursive-readdir');
 var fs = require('fs');
+var local = /^\.|\//;
 
 // Only js and not from node_modules
 var onlySourceFiles = function(filename) {
@@ -11,7 +12,7 @@ var onlySourceFiles = function(filename) {
 };
 
 var onlyDepenencies = function(filename) {
-	return filename.indexOf('.') === -1;
+	return !local.test(filename);
 };
 
 var find = function(path, cb) {

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var detective = require('detective');
 var _ = require('lodash');
 var recursive = require('recursive-readdir');
 var fs = require('fs');
+var core = require('is-core-module');
 var local = /^\.|\//;
 
 // Only js and not from node_modules
@@ -12,7 +13,8 @@ var onlySourceFiles = function(filename) {
 };
 
 var onlyDepenencies = function(filename) {
-	return !local.test(filename);
+	return !local.test(filename)
+		&& !core(filename);
 };
 
 var find = function(path, cb) {

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var onlySourceFiles = function(filename) {
 		&& filename.indexOf('node_modules') === -1;
 };
 
-var onlyDepenencies = function(filename) {
+var onlyDependencies = function(filename) {
 	return !local.test(filename)
 		&& !core(filename);
 };
@@ -37,7 +37,7 @@ var find = function(path, cb) {
 				requires = requires.concat(detective(content));
 
 				if (counter === 0) {
-					cb(null, _.unique(requires.filter(onlyDepenencies)));
+					cb(null, _.unique(requires.filter(onlyDependencies)));
 				}
 			});
 		}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/boo1ean/all-requires",
   "dependencies": {
     "detective": "^3.1.0",
+    "is-core-module": "^1.0.2",
     "lodash": "^2.4.1",
     "recursive-readdir": "^1.2.0"
   }


### PR DESCRIPTION
I discovered my [`object.omit`](https://www.npmjs.com/package/object.omit) require was being ignored because the module name contains a dot, so I’ve made a slight change to the filtering function, based on the [module documentation](http://nodejs.org/api/modules.html#modules_file_modules).

I also found that core modules were being, unnecessarily, installed from npm, so I've added [`is-core-module`](https://www.npmjs.com/package/is-core-module) to prevent their inclusion.