### PR TITLE
Replace lodash with a single-purpose module.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var detective = require('detective');
-var _ = require('lodash');
+var unique = require('array-unique');
 var recursive = require('recursive-readdir');
 var fs = require('fs');
 var core = require('is-core-module');
@@ -37,7 +37,7 @@ var find = function(path, cb) {
 				requires = requires.concat(detective(content));
 
 				if (counter === 0) {
-					cb(null, _.unique(requires.filter(onlyDependencies)));
+					cb(null, unique(requires.filter(onlyDependencies)));
 				}
 			});
 		}

--- a/index.js
+++ b/index.js
@@ -19,6 +19,10 @@ var onlyDependencies = function(filename) {
 
 var find = function(path, cb) {
 	recursive(path, function (err, filenames) {
+		if (err) {
+			return cb(err);
+		}
+
 		var jsFiles = filenames.filter(onlySourceFiles);
 
 		var counter = 0;

--- a/index.js
+++ b/index.js
@@ -24,9 +24,8 @@ var find = function(path, cb) {
 		var counter = 0;
 		var requires = [];
 
-		for (var i in jsFiles) {
+		jsFiles.forEach(function(filename) {
 			counter++;
-			var filename = jsFiles[i];
 
 			fs.readFile(filename, function(err, content) {
 				if (err) {
@@ -40,7 +39,7 @@ var find = function(path, cb) {
 					cb(null, unique(requires.filter(onlyDependencies)));
 				}
 			});
-		}
+		});
 	});
 };
 

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   },
   "homepage": "https://github.com/boo1ean/all-requires",
   "dependencies": {
+    "array-unique": "^0.1.1",
     "detective": "^3.1.0",
     "is-core-module": "^1.0.2",
-    "lodash": "^2.4.1",
     "recursive-readdir": "^1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hey, I did a little refactoring in preparation for some future pull requests. The main change is replacing lodash’s _unique method with [array-unique](https://github.com/jonschlinkert/array-unique). It seemed unnecessary to include all of lodash, when only the unique method was required.