### PR TITLE
Handle module-name/file requires.

### DIFF
--- a/example/d.js
+++ b/example/d.js
@@ -1,0 +1,1 @@
+var d = require('d/file');

--- a/index.js
+++ b/index.js
@@ -17,6 +17,10 @@ var onlyDependencies = function(filename) {
 		&& !core(filename);
 };
 
+var baseModule = function(filename) {
+	return filename.split('/')[0];
+};
+
 var find = function(path, cb) {
 	recursive(path, function (err, filenames) {
 		if (err) {
@@ -40,7 +44,7 @@ var find = function(path, cb) {
 				requires = requires.concat(detective(content));
 
 				if (counter === 0) {
-					cb(null, unique(requires.filter(onlyDependencies)));
+					cb(null, unique(requires.map(baseModule).filter(onlyDependencies)));
 				}
 			});
 		});

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@ var find = require('./');
 
 test('it works', function(assert) {
 	find('./example', function(err, requires) {
-		assert.deepEqual(requires, ['a', 'b', 'c']);
+		assert.deepEqual(requires.sort(), ['a', 'b', 'c', 'd']);
 		assert.end();
 	});
 });


### PR DESCRIPTION
I ran into an issue where `require('module/sub-file')` statements weren’t being resolved properly, so this change fixes that. :)
